### PR TITLE
Updated Vercel Deploy Button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Nuxt 3 Minimal Starter
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fnuxt%2Fstarter%2Ftree%2Fv3-vercel)
-
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/nuxt/starter/tree/v3-vercel&demo-title=Nuxt%203%20Public%20Beta&demo-description=Deploy%20a%20simple%20Nuxt%203%20application%20to%20get%20started.&demo-url=https://nuxt-3.examples.vercel.com&demo-image=https://nuxt-3.examples.vercel.com/screenshot.jpg)
 
 We recommend to look at the [documentation](http://v3.nuxtjs.org).
 


### PR DESCRIPTION
This replaces the previous Deploy Button for [Vercel](https://vercel.com) with a better one – the one mentioned in [this Tweet](https://twitter.com/vercel/status/1448010726828879878).