### PR TITLE
fix(playground): use buildModules instead of modules

### DIFF
--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -2,7 +2,7 @@ import { defineNuxtConfig } from 'nuxt3'
 import MyModule from '..'
 
 export default defineNuxtConfig({
-  modules: [
+  buildModules: [
     MyModule
   ],
   myModule: {


### PR DESCRIPTION
I started a module from this repository recently and noticed (thanks to @benjamincanac) that if using `modules` instead of `buildModules`, things like auto-imports hooks and type generation won't work properly.

I don't know if this is an issue upstream or the expected behavior, but I would suggest using `buildModules` as a default instead of `modules` because there is no documentation yet on these behaviors.