### PR TITLE
Force set NODE_ENV to production when building nuxt.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "scripts": {
     "dev": "nuxi dev",
-    "build": "nuxi build",
+    "build": "NODE_ENV=production nuxi build",
     "start": "node .output/server/index.mjs"
   },
   "devDependencies": {


### PR DESCRIPTION
Force set NODE_ENV to production to prevent watching build (aka infinite build) for users who have `NODE_ENV` set to `dev` globally. 

https://github.com/nuxt/framework/discussions/3207#discussioncomment-2164258

Actually, it would be better to change build command to have `dev` nuxt option set to `false`, not related to user environment, but I'm not sure here. What do you think?