### PR TITLE
chore: infer types for `src` dir

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "./playground/.nuxt/tsconfig.json"
+  "extends": "./playground/.nuxt/tsconfig.json",
+  "include": ["./src/**/*"]
 }


### PR DESCRIPTION
Otherwise, we have type mismatches, because the Nuxt context is missing.