### PR TITLE
fix: broken link to deployment docs in v3 starter README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,4 +39,4 @@ Locally preview production build:
 npm run preview
 ```
 
-Checkout the [deployment documentation](https://v3.nuxtjs.org/docs/deployment) for more information.
+Checkout the [deployment documentation](https://v3.nuxtjs.org/guide/deploy/presets) for more information.


### PR DESCRIPTION
The link in the v3 starter at the bottom of the README.md (referring to deployment) takes a user to a page that 404's currently.