### PR TITLE
fix: remove unnecessary <NuxtLayout>

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -1,7 +1,5 @@
 <template>
-  <NuxtLayout>
-    <NuxtPage />
-  </NuxtLayout>
+  <NuxtPage />
 </template>
 
 <style>


### PR DESCRIPTION
`<NuxtLayout>` is unnecessary for documentDriven mode.

It also **breaks page transitions** (blank page before reload) (and sometimes duplicates the layout) when adding a default layout, and, the page *navigated to*, uses another layout in the frontmatter, than the one *navigated from*.

Example `layouts/default.vue`:
```vue
<template>
    <slot />
</template>
```
and navigating from `/` to `/about` with clicking on the link (just typing `/about` does **not** cause a blank page)

Also this warning shows up just sometimes:
```
 WARN  Using <NuxtLayout> inside app.vue will cause unwanted layout shifting in your application.Consider removing <NuxtLayout> from app.vue and using it in your pages.
```

**Playground:** https://stackblitz.com/edit/github-bngmmu