### PR TITLE
chore: update CodeSandbox links

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ $ npx nuxi init -t v3 nuxt-app
 
 Name | Description | Local     | Online |
 -----|-------------|-----------|--------|
-[v3](https://github.com/nuxt/starter/tree/v3) | [Nuxt 3](https://github.com/nuxt/framework) | `npx nuxi init nuxt-app` | [Stackblitz](https://stackblitz.com/github/nuxt/starter/tree/v3-stackblitz) / [CodeSandbox](https://codesandbox.io/s/github/nuxt/starter/tree/v3-codesandbox) |
+[v3](https://github.com/nuxt/starter/tree/v3) | [Nuxt 3](https://github.com/nuxt/framework) | `npx nuxi init nuxt-app` | [Stackblitz](https://stackblitz.com/github/nuxt/starter/tree/v3-stackblitz) / [CodeSandbox](https://codesandbox.io/p/github/nuxt/starter/v3-codesandbox) |
 [module](https://github.com/nuxt/starter/tree/module) | Nuxt Module with [Module Builder](https://github.com/nuxt/module-builder) | `npx nuxi init my-module -t module` | - |
-[content](https://github.com/nuxt/starter/tree/content) | [Nuxt Content](https://github.com/nuxt/content) | `npx nuxi init content-app -t content` | [Stackblitz](https://stackblitz.com/github/nuxt/starter/tree/content) / [CodeSandbox](https://codesandbox.io/s/github/nuxt/starter/tree/content) |
-[doc-driven](https://github.com/nuxt/starter/tree/doc-driven) | [Document Driven mode](https://content.nuxtjs.org/guide/writing/document-driven) | `npx nuxi init doc-driven-app -t doc-driven` | [Stackblitz](https://stackblitz.com/github/nuxt/starter/tree/doc-driven) / [CodeSandbox](https://codesandbox.io/s/github/nuxt/starter/tree/doc-driven) |
-[v2-bridge](https://github.com/nuxt/starter/tree/v2-bridge) | [Nuxt 2](https://github.com/nuxt/nuxt.js) + [Bridge](https://github.com/nuxt/bridge) | `npx nuxi init nuxt-bridge-app -t v2-bridge` | [Stackblitz](https://stackblitz.com/github/nuxt/starter/tree/v2-bridge) / [CodeSandbox](https://codesandbox.io/s/github/nuxt/starter/tree/v2-bridge-codesandbox) |
-[v2](https://github.com/nuxt/starter/tree/v2) | [Nuxt 2](https://github.com/nuxt/nuxt.js) | `npx nuxi init nuxt2-app -t v2` | [Stackblitz](https://stackblitz.com/github/nuxt/starter/tree/v2-stackblitz) / [CodeSandbox](https://codesandbox.io/s/github/nuxt/starter/tree/v2-codesandbox) |
+[content](https://github.com/nuxt/starter/tree/content) | [Nuxt Content](https://github.com/nuxt/content) | `npx nuxi init content-app -t content` | [Stackblitz](https://stackblitz.com/github/nuxt/starter/tree/content) / [CodeSandbox](https://codesandbox.io/p/github/nuxt/starter/content) |
+[doc-driven](https://github.com/nuxt/starter/tree/doc-driven) | [Document Driven mode](https://content.nuxtjs.org/guide/writing/document-driven) | `npx nuxi init doc-driven-app -t doc-driven` | [Stackblitz](https://stackblitz.com/github/nuxt/starter/tree/doc-driven) / [CodeSandbox](https://codesandbox.io/p/github/nuxt/starter/doc-driven) |
+[v2-bridge](https://github.com/nuxt/starter/tree/v2-bridge) | [Nuxt 2](https://github.com/nuxt/nuxt.js) + [Bridge](https://github.com/nuxt/bridge) | `npx nuxi init nuxt-bridge-app -t v2-bridge` | [Stackblitz](https://stackblitz.com/github/nuxt/starter/tree/v2-bridge) / [CodeSandbox](https://codesandbox.io/p/github/nuxt/starter/v2-bridge-codesandbox) |
+[v2](https://github.com/nuxt/starter/tree/v2) | [Nuxt 2](https://github.com/nuxt/nuxt.js) | `npx nuxi init nuxt2-app -t v2` | [Stackblitz](https://stackblitz.com/github/nuxt/starter/tree/v2-stackblitz) / [CodeSandbox](https://codesandbox.io/p/github/nuxt/starter/v2-codesandbox) |
 
 ## Contribution
 


### PR DESCRIPTION
Hello team!

In this PR, I updated the links for the starter CodeSandbox projects to the new version of CodeSandbox. This is a more smooth experience and should also work faster and more consistently with the local environment.

These are the new links:
- v3 on CodeSandbox: https://codesandbox.io/p/github/nuxt/starter/v3-codesandbox
- Content: https://codesandbox.io/p/github/nuxt/starter/content
- doc-driven: https://codesandbox.io/p/github/nuxt/starter/doc-driven
- v2-bridge: https://codesandbox.io/p/github/nuxt/starter/v2-bridge-codesandbox
- v2 starter: https://codesandbox.io/p/github/nuxt/starter/v2-codesandbox


Thank you.