### PR TITLE
feat: reflect move of sidebase to public org

### DIFF
--- a/templates/community/sidebase.json
+++ b/templates/community/sidebase.json
@@ -2,5 +2,5 @@
   "name": "nuxt-sidebase",
   "defaultDir": "nuxt-sidebase-app",
   "url": "https://sidebase.io",
-  "tar": "https://codeload.github.com/sidestream-tech/sidebase/tar.gz/refs/heads/main"
+  "tar": "https://codeload.github.com/sidebase/sidebase/tar.gz/refs/heads/main"
 }


### PR DESCRIPTION
We moved `sidestream-tech/sidebase` to `sidebase/sidebase` to have everything grouped and consolidate our open-source effort in one org.

We ensured that nothing will break (https://github.com/orgs/community/discussions/22669), but of course it's better to have the correct urls in place everywhere.