### PR TITLE
fix: remove unnecessary app.vue in doc-driven

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -1,9 +1,0 @@
-<template>
-  <NuxtPage />
-</template>
-
-<style>
-body {
-  padding: 10px 20px;
-}
-</style>


### PR DESCRIPTION
I think an `app.vue` is a bit confusing and is definitely not needed  for doc-driven mode. 