### PR TITLE
fix(telemetry): disable from nuxt.config

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -2,5 +2,5 @@ import { defineNuxtConfig } from 'nuxt'
 
 // https://v3.nuxtjs.org/api/configuration/nuxt.config
 export default defineNuxtConfig({
-
+  telemetry: false
 })


### PR DESCRIPTION
disable telemetry by default as it is prompted in a read-only terminal on CodeSandbox

Maybe `.nuxtrc` is more suited to that?