### PR TITLE
chore: exclude recommended vscode files from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,12 @@ coverage
 .nyc_output
 
 # VSCode
-.vscode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
 
 # Intellij idea
 *.iml


### PR DESCRIPTION
VS Code recommends that some of the workspace-related files are commited. Thus, we update gitignore accordingly, using the preset https://www.toptal.com/developers/gitignore/api/visualstudiocode.