### PR TITLE
chore: rename dev:prepare to prepare

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,5 @@
 
 ## Development
 
-- Run `npm run dev:prepare` to generate type stubs.
+- Run `npm run prepare` to generate type stubs.
 - Use `npm run dev` to start [playground](./playground) in development mode.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "prepack": "nuxt-module-build",
     "dev": "nuxi dev playground",
     "dev:build": "nuxi build playground",
-    "dev:prepare": "nuxt-module-build --stub && nuxi prepare playground"
+    "prepare": "nuxt-module-build --stub && nuxi prepare playground"
   },
   "dependencies": {
     "@nuxt/kit": "^3.0.0-rc.13"


### PR DESCRIPTION
Since the tsconfig in the root references the tsconfig of the playground, one has to call `nuxi prepare playground` before running everything else. In particular, it is needed before `prepack`. Renaming `dev:prepare` to `prepare` takes care of this automatically.