### PR TITLE
fix(types): include src and playground in tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,7 @@
 {
-  "extends": "./playground/.nuxt/tsconfig.json"
+  "extends": "./playground/.nuxt/tsconfig.json",
+  "include": [
+    "./src",
+    "./playground"
+  ]
 }


### PR DESCRIPTION
I found myself needing this in order for module.ts and plugin.ts to be correctly typed when creating a module in a mono repo with a different tsconfig in a higher folder (https://github.com/vuejs/vuefire/tree/main)