### PR TITLE
chore: Add `.DS_Store` to ignored files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 .output
 .env
 dist
+.DS_Store


### PR DESCRIPTION
MacOS system file, should not be committed.