### PR TITLE
 Remove unsemantic blockquote

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🪄 Nuxt Starter Templates
 
-> Quickly get started with a minimal Nuxt starter template!
+Quickly get started with a minimal Nuxt starter template!
 
 ## Quick start
 


### PR DESCRIPTION
> A block quote marker, optionally preceded by up to three spaces of
> indentation, consists of (a) the character `>` together with a
> following space of indentation, or (b) a single character `>` not
> followed by a space of indentation.

— CommonMark Spec v0.30, https://spec.commonmark.org/0.30/#block-quotes

`>` denotes a `<blockquote>` in Markdown and is rendered as such.

> The blockquote element represents a section that is quoted from
> another source.

— W3C HTML spec, https://html.spec.whatwg.org/multipage/grouping-content.html#the-blockquote-element

Since this block in the README isn’t quoting any source, itself or otherwise, the usage of this element is not semantic and should be removed. It’s unclear what value the blockquote is providing.