### PR TITLE
chore: highlight shell session syntax correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ Head over to [nuxt.new](https://nuxt.new) to get started quickly.
 
 You can use `nuxi` CLI to clone latest template to an empty directory:
 
-```sh
+```sh-session
 $ npx nuxi init [-t,--template=<template>] [<dir>]
 ```
 
 **Example:** Clone `v3` to `my-app` directory:
 
-```sh
+```sh-session
 $ npx nuxi init -t v3 nuxt-app
 ```
 


### PR DESCRIPTION
These blocks are meant to represent a shell session inside one’s terminal emulator—not a shell script. As such this fix is to set the appropriate syntax highlighting for the code block.