### PR TITLE
chore: add index.ts to module starter

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,17 @@
+/**
+ * This file won't be run by Nuxt when loading the module.
+ *
+ * It is used to expose utils for the user.
+ *
+ * export const myUtil = () => console.log('This is myUtil from the module')
+ */
+
+/**
+ * The module user can:
+ *
+ * import { myUtil } from 'my-module'
+ */
+
+/**
+ * You can safely remove this file if you don't need to expose utils.
+ */


### PR DESCRIPTION
Explain that module authors can expose utils outside of Nuxt context for end users.

Actually I believe this does not work at all 🤔 
- package exports: https://github.com/nuxt/starter/blob/358482cb7ae624c3c8a0d5082bda2d9dde94826b/package.json#L8-L14

When running `npm run prepack`:
<img width="195" alt="CleanShot 2023-03-03 at 11 25 19@2x" src="https://user-images.githubusercontent.com/904724/222696430-200932ad-461b-4043-95f5-650ecde62751.png">
