### PR TITLE
chore: add name to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nuxt-starter",
+  "name": "nuxt-app",
   "private": true,
   "scripts": {
     "build": "nuxt build",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "nuxt-starter",
   "private": true,
   "scripts": {
     "build": "nuxt build",


### PR DESCRIPTION
Some cloud hostings using buildpacks (Kinsta App Hosting, for example) are throwing an error because the `package.json` is missing the `name` field.

Also, in theory, it's a mandatory field :)
> A package.json file must contain "name" and "version" fields
https://docs.npmjs.com/creating-a-package-json-file