### PR TITLE
fix: add backticks around localhost link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ pnpm install
 
 ## Development Server
 
-Start the development server on http://localhost:3000
+Start the development server on `http://localhost:3000`
 
 ```bash
 npm run dev


### PR DESCRIPTION
My first contribution. My apologies if I do something wrong. 😔

Pull request is to update the `README.md` of `starter` `v3` to prevent **Markdown** warnings about bare links as per: [https://github.com/updownpress/markdown-lint/blob/master/rules/034-no-bare-urls.md](https://github.com/updownpress/markdown-lint/blob/master/rules/034-no-bare-urls.md)
