### PR TITLE
chore(themes): update themes to use `.starters` directory

### DIFF
--- a/templates/themes/alpine.json
+++ b/templates/themes/alpine.json
@@ -3,5 +3,5 @@
   "defaultDir": "blog",
   "url": "https://alpine.nuxt.space",
   "tar": "https://codeload.github.com/nuxt-themes/alpine-starter/tar.gz/refs/heads/main",
-  "subdir": ""
+  "subdir": ".starters/default"
 }

--- a/templates/themes/docus.json
+++ b/templates/themes/docus.json
@@ -3,5 +3,5 @@
   "defaultDir": "docs",
   "url": "https://docus.dev",
   "tar": "https://codeload.github.com/nuxt-themes/docus-docs-starter/tar.gz/refs/heads/main",
-  "subdir": ""
+  "subdir": ".starters/default"
 }


### PR DESCRIPTION
Hey, following https://github.com/nuxtlabs/studio-app/issues/821 ;

This PR updates the themes init command to use the new starters location on both Alpine and Docus.