### PR TITLE
chore: update package manager commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,22 +7,29 @@ Look at the [Nuxt 3 documentation](https://nuxt.com/docs/getting-started/introdu
 Make sure to install the dependencies:
 
 ```bash
-# yarn
-yarn install
-
 # npm
 npm install
 
 # pnpm
 pnpm install
+
+# yarn
+yarn install
 ```
 
 ## Development Server
 
-Start the development server on `http://localhost:3000`
+Start the development server on `http://localhost:3000`:
 
 ```bash
+# npm
 npm run dev
+
+# pnpm
+pnpm run dev
+
+# yarn
+yarn dev
 ```
 
 ## Production
@@ -30,13 +37,27 @@ npm run dev
 Build the application for production:
 
 ```bash
+# npm
 npm run build
+
+# pnpm
+pnpm run build
+
+# yarn
+yarn build
 ```
 
 Locally preview production build:
 
 ```bash
+# npm
 npm run preview
+
+# pnpm
+pnpm run preview
+
+# yarn
+yarn preview
 ```
 
 Check out the [deployment documentation](https://nuxt.com/docs/getting-started/deployment) for more information.


### PR DESCRIPTION
Added remaining commands for completeness. Package managers are displayed in alphabetical order. We might make the code blocks shorter, e.g.:

> Build the application for production:
> 
> ```bash
> npm run build
> pnpm run build
> yarn build
> ```

... or:

> Build the application for production:
> 
> - `npm run build`
> - `pnpm run build`
> - `yarn build`

... or stick to one package manager by default, as some frameworks do (not ideal).