### PR TITLE
chore: remove duplicate .env line in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@ dist
 .output
 .vercel_build_output
 .build-*
-.env
 .netlify
 
 # Env


### PR DESCRIPTION
Removed a duplicate .env line in .gitignore, which was displayed as an error in my environment.