### PR TITLE
docs: fix deployment documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,4 +39,4 @@ Locally preview production build:
 npm run preview
 ```
 
-Checkout the [deployment documentation](https://v3.nuxtjs.org/docs/deployment) for more information.
+Checkout the [deployment documentation](https://nuxt.com/docs/getting-started/deployment) for more information.


### PR DESCRIPTION
Replaces broken deplyoment documentation link https://v3.nuxtjs.org/docs/deployment with the current working version https://nuxt.com/docs/getting-started/deployment