### PR TITLE
Fix relative path in tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,3 @@
 {
-  "extends": "./.nuxt/tsconfig.json"
+  "extends": "./playground/.nuxt/tsconfig.json"
 }


### PR DESCRIPTION
This fixes the typescript config. the tests were failing and also there was type warning in the editor.