### PR TITLE
fix: add nuxi and migrate nuxi command

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,16 +3,17 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "dev": "nuxt dev",
-    "build": "nuxt build",
-    "start": "node .output/server/index.mjs",
-    "generate": "nuxt generate",
+    "dev": "nuxi dev",
+    "build": "nuxi build",
+    "start": "nuxi preview",
+    "generate": "nuxi generate",
     "postinstall": "yarn upgrade"
   },
   "dependencies": {},
   "devDependencies": {
     "core-js": "^3.9.1",
     "@nuxt/bridge": "npm:@nuxt/bridge-edge",
+    "nuxi": "latest",
     "nuxt-edge": "latest"
   }
 }


### PR DESCRIPTION
Fixes: https://github.com/nuxt/bridge/issues/908

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
The latest Nuxt Bridge does not include `nuxi`, so I added it to dependencies.
Also, changed to `nuxi` command.

