### PR TITLE
chore: disable devtools

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,4 +1,4 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
-  devtools: { enabled: true }
+  devtools: { enabled: false }
 })


### PR DESCRIPTION
We have gotten reports from users that enabling devtools breaks the starter on StackBlitz. There seems to be something breaking it on our side with the `npm install` but we need to further investigate this.

It looks like a (temporary) fix would be to either
1) disable devtools
2) add `@nuxt/devtools` to the dependency list in the `package.json`

Not sure what the preferred method is but wanted to get the conversation going and make sure the starter at least works.