### PR TITLE
fix: update extends to be an array with fresh layer

### DIFF
--- a/.playground/nuxt.config.ts
+++ b/.playground/nuxt.config.ts
@@ -1,3 +1,3 @@
 export default defineNuxtConfig({
-  extends: '..'
+  extends: ['..']
 })


### PR DESCRIPTION
This change addresses the issue with a new layer template using invalid typing for the `extends` configuration.

Fixes https://github.com/nuxt/starter/issues/554

