### PR TITLE
fix: added .nuxtrc & updated tsconfig path

### DIFF
--- a/.nuxtrc
+++ b/.nuxtrc
@@ -1,0 +1,1 @@
+typescript.includeWorkspace = true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,3 @@
 {
-  "extends": "./.nuxt/tsconfig.json"
+  "extends": "./playground/.nuxt/tsconfig.json"
 }


### PR DESCRIPTION
@danielroe 
1. I've added `.nuxtrc` with: `typescript.includeWorkspace = true`, so nuxt imports would be recognized by TS correctly. Layers starter has it by default, but "module starter" doesn't.
2. Also u updated path in tsconfig.json