### PR TITLE
feat(module): add runtime server folder

### DIFF
--- a/src/runtime/server/tsconfig.json
+++ b/src/runtime/server/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../.nuxt/tsconfig.server.json",
+}


### PR DESCRIPTION
Hello 👋,

This PR add a tsconfig in the server folder to enable import from the correct `#import` path and to have access to the server imports.

related to https://github.com/nuxt/nuxt/issues/27535 where I will add details about this in the documentation.

for the story: https://x.com/soubiran_/status/1799481068686643434
