### PR TITLE
fix(layer): prevent breaking postinstall script when installing package

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "build": "nuxt build .playground",
     "generate": "nuxt generate .playground",
     "preview": "nuxt preview .playground",
-    "lint": "eslint .",
-    "postinstall": "nuxt prepare .playground"
+    "lint": "eslint ."
   },
   "devDependencies": {
     "@nuxt/eslint": "latest",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "./nuxt.config.ts",
   "scripts": {
     "dev": "nuxi dev .playground",
+    "dev:prepare": "nuxt prepare .playground",
     "build": "nuxt build .playground",
     "generate": "nuxt generate .playground",
     "preview": "nuxt preview .playground",


### PR DESCRIPTION
A layer that has been kickstarted using this template results in an error when it's being installed via package manager (e.g. `pnpm add @my-scope/my-layer`), because the postinstall script runs.

This PR removes the breaking postinstall script.

See also https://github.com/nuxt/starter/pull/16#issuecomment-1110847591