### PR TITLE
fix(layer): move breaking module registration to playground

### DIFF
--- a/.playground/nuxt.config.ts
+++ b/.playground/nuxt.config.ts
@@ -1,3 +1,4 @@
 export default defineNuxtConfig({
-  extends: ['..']
+  extends: ['..'],
+  modules: ['@nuxt/eslint']
 })

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,5 +1,4 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
-  devtools: { enabled: true },
-  modules: ['@nuxt/eslint']
+  devtools: { enabled: true }
 })


### PR DESCRIPTION
The layers `nuxt.config.ts` registers a module which is not provided as a dependency. This results in an error if the consumer project does not install the package.

To make the template easier to use the module registration is moved to the playground.