### PR TITLE
fix: eslint config path for nuxt

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,3 +1,3 @@
-import withNuxt from './.nuxt/eslint.config.mjs'
+import withNuxt from './.playground/.nuxt/eslint.config.mjs'
 
 export default withNuxt()


### PR DESCRIPTION
Update ESLint configuration path to correctly import from "./.playground/.nuxt" for layers.

- Updated ESLint config path from "./.nuxt/eslint.config.mjs" to "./.playground/.nuxt/eslint.config.mjs"
- Ensured linting works correctly for layers

This change resolves the issue where the ESLint config was incorrectly importing from ".nuxt" instead of the intended "./.playground/.nuxt" for layers.