### PR TITLE
ci(module): fix `test` job failing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,5 +38,8 @@ jobs:
       - name: Install dependencies
         run: npx nypm@latest i
 
+      - name: Playground prepare
+        run: npm run dev:prepare
+
       - name: Test
         run: npm run test


### PR DESCRIPTION
The template's included workflow did not generate the types stub and was failing.

[Before sample](https://github.com/NamesMT/nuxt-modern-cropper/actions/runs/9973723608)

[After sample](https://github.com/NamesMT/nuxt-modern-cropper/actions/runs/9974366727)