### PR TITLE
fix: add Module options TypeScript to PublicRuntimeConfig

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -1,5 +1,13 @@
 import { defineNuxtModule, addPlugin, createResolver } from '@nuxt/kit'
 
+// PublicRuntimeConfig Typescript supplement
+declare module '@nuxt/schema' {
+  interface PublicRuntimeConfig {
+    // this key is used meta.configKey
+    myModule: ModuleOptions
+  }
+}
+
 // Module options TypeScript interface definition
 export interface ModuleOptions {}
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
When you get data from runtimeConfig, you get the type unknown
![image](https://github.com/user-attachments/assets/19e654ad-6e0f-44be-a8cb-f8fba08277ee)

```ts
export interface ModuleOptions {
  size?: number,
}

 _nuxt.options.runtimeConfig.public.myModule.size  // "_nuxt.options.runtimeConfig.public.myModule" is of type "unknown"
```
after,Able to recognize types
![image](https://github.com/user-attachments/assets/9c3ec103-7319-45a2-b719-13c1800a6460)


