### PR TITLE
fix(package): pin to pnpm 9.15.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nuxt-content-starter",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@10.2.1",
+  "packageManager": "pnpm@9.15.5",
   "scripts": {
     "build": "nuxt build",
     "dev": "nuxt dev",


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In [pnpm 10](https://github.com/pnpm/pnpm/releases/tag/v10.0.0), lifecycle scripts of dependencies are not executed during installation by default, this results in ignored scripts:

![Screenshot 2025-02-10 at 17 06 23](https://github.com/user-attachments/assets/a7deafab-d41e-477f-9042-3439b4a23b0d)

I think the framework team might be aware of it since it also impacts `sharp` and `esbuild`.

As a workaround for the moment, I propose to pin the Content starter to pnpm9 to be sure it's deployable from GitHub pages and NuxtHub.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
