### PR TITLE
chore(ci): fix corepack signature issue using a workaround

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - run: corepack enable
+
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+
+      - run: npm i -g --force corepack@latest && corepack enable
 
       - name: Install dependencies
         run: npx nypm@latest i
@@ -30,10 +32,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - run: corepack enable
+
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+
+      - run: npm i -g --force corepack@latest && corepack enable
 
       - name: Install dependencies
         run: npx nypm@latest i


### PR DESCRIPTION
Currently CIs are failing because of [outdated signature in older Corepack versions](https://github.com/nodejs/corepack/issues/612), this fixes the CI by forcing an install for the latest version of `corepack`