### PR TITLE
chore: add `prepare` command prior to `dev`. #1305

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "scripts": {
     "prepack": "nuxt-module-build build",
-    "dev": "nuxi dev playground",
+    "dev": "npm run dev:prepare && nuxi dev playground",
     "dev:build": "nuxi build playground",
     "dev:prepare": "nuxt-module-build build --stub && nuxt-module-build prepare && nuxi prepare playground",
     "release": "npm run lint && npm run test && npm run prepack && changelogen --release && npm publish && git push --follow-tags",


### PR DESCRIPTION
Closes #1305 

What should we do with the rest of templates shown in https://nuxt.new/?

I don't mind to update them, just want to verify if that's ok