### PR TITLE
chore: bump the compat date

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,5 +1,5 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
-  compatibilityDate: '2024-11-01',
+  compatibilityDate: '2025-05-15',
   devtools: { enabled: true }
 })


### PR DESCRIPTION
This opts into the newer Deno 2 preset for Nitro that does much less polyfilling.
