### PR TITLE
ci: add workflow to reset lockfile for stackblitz

### DIFF
--- a/.github/workflows/stackblitz.yml
+++ b/.github/workflows/stackblitz.yml
@@ -1,9 +1,9 @@
 name: reset lockfile
 
 on:
-  push:
+  pull_request:
     branches:
-      - '**-stackblitz'
+      - 'renovate/*-stackblitz*'
 
 permissions:
   contents: write

--- a/.github/workflows/stackblitz.yml
+++ b/.github/workflows/stackblitz.yml
@@ -1,0 +1,34 @@
+name: reset lockfile
+
+on:
+  push:
+    branches:
+      - '**-stackblitz'
+
+permissions:
+  contents: write
+
+jobs:
+  reset-lockfile:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: reset lockfile
+        run: |
+          cat << 'EOF' > pnpm-lock.yaml
+          lockfileVersion: '6.0'
+          
+          settings:
+            autoInstallPeers: true
+            excludeLinksFromLockfile: false
+          EOF
+
+      - name: Commit changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .
+          git commit -m "chore: reset pnpm-lock.yml for stackblitz"
+          git push

--- a/.github/workflows/stackblitz.yml
+++ b/.github/workflows/stackblitz.yml
@@ -1,7 +1,7 @@
 name: reset lockfile
 
 on:
-  pull_request:
+  push:
     branches:
       - 'renovate/*-stackblitz*'
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 node_modules
 yarn.lock
 dist
+.idea


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/starter/pull/1392#issuecomment-3083344572

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds an workflow for every push on all branches ending with `-stackblitz`. It resets the pnpm lockfile, that was falsly generated by the renovate bot.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
