### PR TITLE
chore: add descriptions for nuxt templates

### DIFF
--- a/templates/content.json
+++ b/templates/content.json
@@ -1,5 +1,6 @@
 {
   "name": "content",
+  "description": "A minimal content-driven website.",
   "defaultDir": "nuxt-app",
   "url": "https://content.nuxt.com",
   "tar": "https://codeload.github.com/nuxt/starter/tar.gz/refs/heads/content"

--- a/templates/content.json
+++ b/templates/content.json
@@ -1,6 +1,6 @@
 {
   "name": "content",
-  "description": "A minimal content-driven website.",
+  "description": "Content-driven website",
   "defaultDir": "nuxt-app",
   "url": "https://content.nuxt.com",
   "tar": "https://codeload.github.com/nuxt/starter/tar.gz/refs/heads/content"

--- a/templates/doc-driven.json
+++ b/templates/doc-driven.json
@@ -1,5 +1,6 @@
 {
   "name": "doc-driven",
+  "description": "A minimal document-driven website.",
   "defaultDir": "nuxt-app",
   "url": "https://content.nuxt.com",
   "tar": "https://codeload.github.com/nuxt/starter/tar.gz/refs/heads/doc-driven"

--- a/templates/doc-driven.json
+++ b/templates/doc-driven.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-driven",
-  "description": "A minimal document-driven website.",
+  "description": "Document-driven website",
   "defaultDir": "nuxt-app",
   "url": "https://content.nuxt.com",
   "tar": "https://codeload.github.com/nuxt/starter/tar.gz/refs/heads/doc-driven"

--- a/templates/hub.json
+++ b/templates/hub.json
@@ -1,6 +1,6 @@
 {
   "name": "hub",
-  "description": "A minimal app running on the edge with NuxtHub.",
+  "description": "App running on the edge with NuxtHub",
   "defaultDir": "nuxthub-app",
   "url": "https://hub.nuxt.com",
   "tar": "https://codeload.github.com/nuxt-hub/hello-edge/tar.gz/refs/heads/main"

--- a/templates/hub.json
+++ b/templates/hub.json
@@ -1,5 +1,6 @@
 {
   "name": "hub",
+  "description": "A minimal app running on the edge with NuxtHub.",
   "defaultDir": "nuxthub-app",
   "url": "https://hub.nuxt.com",
   "tar": "https://codeload.github.com/nuxt-hub/hello-edge/tar.gz/refs/heads/main"

--- a/templates/layer.json
+++ b/templates/layer.json
@@ -1,5 +1,6 @@
 {
   "name": "layer",
+  "description": "A minimal setup for a standalone Nuxt layer.",
   "defaultDir": "nuxt-layer",
   "url": "https://nuxt.com",
   "tar": "https://codeload.github.com/nuxt/starter/tar.gz/refs/heads/layer"

--- a/templates/layer.json
+++ b/templates/layer.json
@@ -1,6 +1,6 @@
 {
   "name": "layer",
-  "description": "A minimal setup for a standalone Nuxt layer.",
+  "description": "Standalone Nuxt layer",
   "defaultDir": "nuxt-layer",
   "url": "https://nuxt.com",
   "tar": "https://codeload.github.com/nuxt/starter/tar.gz/refs/heads/layer"

--- a/templates/module-devtools.json
+++ b/templates/module-devtools.json
@@ -1,5 +1,6 @@
 {
   "name": "module-devtools",
+  "description": "Starter to create your first Nuxt module with DevTools integration.",
   "defaultDir": "nuxt-module",
   "url": "https://nuxt.com",
   "tar": "https://codeload.github.com/nuxt/starter/tar.gz/refs/heads/module-devtools"

--- a/templates/module-devtools.json
+++ b/templates/module-devtools.json
@@ -1,6 +1,6 @@
 {
   "name": "module-devtools",
-  "description": "Starter to create your first Nuxt module with DevTools integration.",
+  "description": "Nuxt module with DevTools integration",
   "defaultDir": "nuxt-module",
   "url": "https://nuxt.com",
   "tar": "https://codeload.github.com/nuxt/starter/tar.gz/refs/heads/module-devtools"

--- a/templates/module.json
+++ b/templates/module.json
@@ -1,5 +1,6 @@
 {
   "name": "module",
+  "description": "Starter to create your first Nuxt module.",
   "defaultDir": "nuxt-module",
   "url": "https://nuxt.com",
   "tar": "https://codeload.github.com/nuxt/starter/tar.gz/refs/heads/module"

--- a/templates/module.json
+++ b/templates/module.json
@@ -1,6 +1,6 @@
 {
   "name": "module",
-  "description": "Starter to create your first Nuxt module.",
+  "description": "Nuxt module",
   "defaultDir": "nuxt-module",
   "url": "https://nuxt.com",
   "tar": "https://codeload.github.com/nuxt/starter/tar.gz/refs/heads/module"

--- a/templates/ui-vue.json
+++ b/templates/ui-vue.json
@@ -1,6 +1,6 @@
 {
   "name": "ui-vue",
-  "description": "Use Nuxt UI with a plain Vue website.",
+  "description": "Use Nuxt UI with a plain Vue website",
   "defaultDir": "vue-app",
   "url": "https://ui.nuxt.com",
   "tar": "https://codeload.github.com/nuxt-ui-templates/starter-vue/tar.gz/refs/heads/main"

--- a/templates/ui-vue.json
+++ b/templates/ui-vue.json
@@ -1,5 +1,6 @@
 {
   "name": "ui-vue",
+  "description": "Use Nuxt UI with a plain Vue website.",
   "defaultDir": "vue-app",
   "url": "https://ui.nuxt.com",
   "tar": "https://codeload.github.com/nuxt-ui-templates/starter-vue/tar.gz/refs/heads/main"

--- a/templates/ui.json
+++ b/templates/ui.json
@@ -1,6 +1,6 @@
 {
   "name": "ui",
-  "description": "Starter with Nuxt UI.",
+  "description": "App using Nuxt UI",
   "defaultDir": "nuxt-app",
   "url": "https://ui.nuxt.com",
   "tar": "https://codeload.github.com/nuxt-ui-templates/starter/tar.gz/refs/heads/main"

--- a/templates/ui.json
+++ b/templates/ui.json
@@ -1,5 +1,6 @@
 {
   "name": "ui",
+  "description": "Starter with Nuxt UI.",
   "defaultDir": "nuxt-app",
   "url": "https://ui.nuxt.com",
   "tar": "https://codeload.github.com/nuxt-ui-templates/starter/tar.gz/refs/heads/main"

--- a/templates/v2-bridge.json
+++ b/templates/v2-bridge.json
@@ -1,6 +1,6 @@
 {
   "name": "v2-bridge",
-  "description": "Use Nuxt 2 with Nuxt Bridge.",
+  "description": "Use Nuxt 2 with Nuxt Bridge",
   "defaultDir": "nuxt-app",
   "url": "https://github.com/nuxt/bridge",
   "tar": "https://codeload.github.com/nuxt/starter/tar.gz/refs/heads/v2-bridge"

--- a/templates/v2-bridge.json
+++ b/templates/v2-bridge.json
@@ -1,5 +1,6 @@
 {
   "name": "v2-bridge",
+  "description": "Use Nuxt 2 with Nuxt Bridge.",
   "defaultDir": "nuxt-app",
   "url": "https://github.com/nuxt/bridge",
   "tar": "https://codeload.github.com/nuxt/starter/tar.gz/refs/heads/v2-bridge"

--- a/templates/v3.json
+++ b/templates/v3.json
@@ -1,5 +1,6 @@
 {
   "name": "v3",
+  "description": "Minimal setup for Nuxt 3 with a single app.vue.",
   "defaultDir": "nuxt-app",
   "url": "https://nuxt.com",
   "tar": "https://codeload.github.com/nuxt/starter/tar.gz/refs/heads/v3"

--- a/templates/v3.json
+++ b/templates/v3.json
@@ -1,6 +1,6 @@
 {
   "name": "v3",
-  "description": "Minimal setup for Nuxt 3 with a single app.vue.",
+  "description": "Minimal setup for Nuxt 3",
   "defaultDir": "nuxt-app",
   "url": "https://nuxt.com",
   "tar": "https://codeload.github.com/nuxt/starter/tar.gz/refs/heads/v3"

--- a/templates/v4-compat.json
+++ b/templates/v4-compat.json
@@ -1,6 +1,6 @@
 {
   "name": "v4-compat",
-  "description": "Use Nuxt 3 with compatibility with Nuxt 4 breaking changes.",
+  "description": "Use Nuxt 3 with compatibility with Nuxt 4 breaking changes",
   "defaultDir": "nuxt-app",
   "url": "https://nuxt.com",
   "tar": "https://codeload.github.com/nuxt/starter/tar.gz/refs/heads/v4-compat"

--- a/templates/v4-compat.json
+++ b/templates/v4-compat.json
@@ -1,5 +1,6 @@
 {
   "name": "v4-compat",
+  "description": "Use Nuxt 3 with compatibility with Nuxt 4 breaking changes.",
   "defaultDir": "nuxt-app",
   "url": "https://nuxt.com",
   "tar": "https://codeload.github.com/nuxt/starter/tar.gz/refs/heads/v4-compat"

--- a/templates/v4.json
+++ b/templates/v4.json
@@ -1,6 +1,6 @@
 {
   "name": "v4",
-  "description": "Minimal setup for Nuxt 4 with a single app.vue.",
+  "description": "Minimal setup for Nuxt 4",
   "defaultDir": "nuxt-app",
   "url": "https://nuxt.com",
   "tar": "https://codeload.github.com/nuxt/starter/tar.gz/refs/heads/v4"

--- a/templates/v4.json
+++ b/templates/v4.json
@@ -1,5 +1,6 @@
 {
   "name": "v4",
+  "description": "Minimal setup for Nuxt 4 with a single app.vue.",
   "defaultDir": "nuxt-app",
   "url": "https://nuxt.com",
   "tar": "https://codeload.github.com/nuxt/starter/tar.gz/refs/heads/v4"


### PR DESCRIPTION
### 📚 Description

this adds a new `description` field to key templates (to be used by nuxt/cli). We can also use this in `nuxt/nuxt.new` (see [current descriptions](https://nuxt.new/) there...)